### PR TITLE
make nbraze aware of top-level metadata in notebook files

### DIFF
--- a/src/nbless/nbraze.py
+++ b/src/nbless/nbraze.py
@@ -27,11 +27,11 @@ def nbraze(in_file: str, extension: str = "") -> Dict[str, str]:
             extension = lang_ext_dict[nb.metadata.language_info.name]
     if not extension and "language_info" not in nb.metadata:
         extension = "py"
-    filenames = (
+    filenames = [
         f"{Path(in_file).stem}_cell{n}.md"
         if cell.cell_type == "markdown"
         else f"{Path(in_file).stem}_cell{n}.{extension}"
         for n, cell in enumerate(nb.cells)
-    )
-    sources = (cell.source for cell in nb.cells)
+        ] + [f"{Path(in_file).stem}_metadata.json"]
+    sources = [cell.source for cell in nb.cells] + [nb.metadata]
     return dict(zip(filenames, sources))

--- a/tests/test_nbless.py
+++ b/tests/test_nbless.py
@@ -89,7 +89,7 @@ def test_language_info(tmp_path: Path):
     nbnode = nbformat.read(nb, as_version=4)
     assert nbnode.metadata.language_info.name == "python"
     fdict = nbraze(nb)
-    assert [Path(f).suffix for f in fdict] == [".md", ".py", ".md"]
+    assert [Path(f).suffix for f in fdict] == [".md", ".py", ".md", ".json"]
     assert fdict["notebook_cell0.md"].startswith("# Background\nMatplotlib")
     assert fdict["notebook_cell1.py"].startswith("import numpy as np\n")
     assert fdict["notebook_cell2.md"].startswith("# Discussion\nMatplotlib")

--- a/tests/test_nbless.py
+++ b/tests/test_nbless.py
@@ -77,7 +77,7 @@ def test_nbconv_file_contents(tmp_path: Path):
 def test_nbraze(tmp_path: Path):
     """Extract code and markdown files from the cells of an input notebook."""
     fdict = nbraze(make_notebook(tmp_path))
-    assert [Path(f).suffix for f in fdict] == [".md", ".py", ".md"]
+    assert [Path(f).suffix for f in fdict] == [".md", ".py", ".md", '.json']
     assert fdict["notebook_cell0.md"].startswith("# Background\nMatplotlib")
     assert fdict["notebook_cell1.py"].startswith("import numpy as np\n")
     assert fdict["notebook_cell2.md"].startswith("# Discussion\nMatplotlib")


### PR DESCRIPTION
Small edits to src/nbraze so that the top-level metadata field is included in the outputs.